### PR TITLE
feat(metadata): add publication provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,27 @@ Publication metadata is resolved from multiple levels:
 
 Each next level overrides the previous one when the same key is defined more
 than once.
+
+Source and Provenance Metadata
+---
+
+Imported publications should preserve original source provenance as active,
+machine-readable metadata under `publication.source`.
+
+Use `publication.source.repository` for the original source repository that was
+imported into this archive. Do not replace it with this destination archive
+repository. If destination/archive metadata must be recorded explicitly, use a
+separate `publication.archive` block instead.
+
+Example:
+
+```json
+{
+  "publication": {
+    "source": {
+      "repository": "https://github.com/example/source-publication.git",
+      "version": "1.0"
+    }
+  }
+}
+```

--- a/src/begin-it/metadata.json
+++ b/src/begin-it/metadata.json
@@ -1,4 +1,9 @@
 {
+  "publication": {
+    "source": {
+      "repository": "https://github.com/shorodilov/article-02.git"
+    }
+  },
   "bibliography": "refs.bib",
   "keywords": [
     "developer",

--- a/src/cs50-review/metadata.json
+++ b/src/cs50-review/metadata.json
@@ -1,4 +1,10 @@
 {
+  "publication": {
+    "source": {
+      "repository": "https://github.com/shorodilov/article-01.git",
+      "version": "1.0"
+    }
+  },
   "bibliography": "refs.bib",
   "keywords": [
     "review",

--- a/src/metadata.schema.json
+++ b/src/metadata.schema.json
@@ -24,6 +24,19 @@
       "description": "The document version",
       "type": "string"
     },
+    "publication": {
+      "description": "Repository-local publication metadata that is not part of standard Pandoc document metadata",
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/$defs/publication-source"
+        },
+        "archive": {
+          "$ref": "#/$defs/publication-archive"
+        }
+      },
+      "additionalProperties": false
+    },
     "subtitle": {
       "type": "string"
     },
@@ -354,6 +367,41 @@
     },
     "font-options": {
       "$ref": "#/$defs/type-str-list-or-str"
+    },
+    "publication-source": {
+      "description": "Original source provenance for an imported publication",
+      "type": "object",
+      "required": [
+        "repository"
+      ],
+      "properties": {
+        "repository": {
+          "description": "Original source repository URL before import into this archive",
+          "type": "string",
+          "format": "uri"
+        },
+        "version": {
+          "description": "Original source publication version, when known",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "publication-archive": {
+      "description": "Destination archive metadata for this repository, separate from original source provenance",
+      "type": "object",
+      "properties": {
+        "repository": {
+          "description": "Destination archive repository URL, if it must be recorded explicitly",
+          "type": "string",
+          "format": "uri"
+        },
+        "path": {
+          "description": "Publication path inside the destination archive repository",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
### Motivation

- Preserve and expose original-source provenance for imported publications as machine-readable metadata. 
- Keep provenance distinct from destination/archive metadata so imported-source attribution is explicit and auditable. 
- Make the provenance shape discoverable and enforceable via the repository metadata schema and docs.

### Description

- Extend `src/metadata.schema.json` with a `publication` object and `$defs` for `publication-source` and `publication-archive` to describe provenance and archive details. 
- Add `publication.source` entries to `src/begin-it/metadata.json` and `src/cs50-review/metadata.json`, preserving the original source repository URLs and the `cs50-review` source version. 
- Add a "Source and Provenance Metadata" section to `README.md` documenting the `publication.source` convention, `publication.archive` usage, and an example JSON snippet. 
- Verified all edited files are valid JSON after the changes.

### Testing

- `jq empty src/metadata.schema.json src/metadata.json src/begin-it/metadata.json src/cs50-review/metadata.json` — succeeded. 
- Loaded the modified JSON files with Python's `json` module to ensure they parse — succeeded. 
- Attempted schema validation with Python `jsonschema` but the `jsonschema` package is not available in the environment, so that check was skipped. 
- Attempted `npx --yes ajv-cli@5 validate -s src/metadata.schema.json -d 'src/**/*.json' --spec=draft2020` but the run was blocked by the npm registry returning `403 Forbidden`, so full AJV validation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e1b252b68832aa6b35acfdb7c8d47)