### PR TITLE
docs: document AI commit authorship

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ AI Editing Rules
 ---
 
 - When an AI agent or AI-assisted tool creates a commit, set the Git author to
-  the tool or model identity in the form `<model> <email>`. Examples include
+  the tool or model identity in the form `<model> <email@domain>`. Examples include
   `GPT-5.5 <noreply@openai.com>` and
   `Copilot {model} <noreply@github.com>`.
 - Prefer small, reviewable changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,10 @@ Adaptations and Attribution
 AI Editing Rules
 ---
 
+- When an AI agent or AI-assisted tool creates a commit, set the Git author to
+  the tool or model identity in the form `<model> <email>`. Examples include
+  `GPT-5.5 <noreply@openai.com>` and
+  `Copilot {model} <noreply@github.com>`.
 - Prefer small, reviewable changes.
 - Do not make broad style rewrites, tone changes, or language normalization
   without explicit instruction.

--- a/docs/COMMIT_MESSAGE.md
+++ b/docs/COMMIT_MESSAGE.md
@@ -40,3 +40,24 @@ recommends `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`,
 
 Footers other than `BREAKING CHANGE: <description>` may be provided and
 follow a convention similar to Git trailer format.
+
+## Commit author for AI-assisted commits
+
+When an AI agent or AI-assisted tool creates a commit, use a Git author
+identity that names the model or tool and includes an email address. Keep
+the author string in this form:
+
+```plain
+<model> <email>
+```
+
+Examples:
+
+```plain
+GPT-5.5 <noreply@openai.com>
+Copilot {model} <noreply@github.com>
+```
+
+Use the specific model or tool identity that produced the commit. Do not
+replace the AI author with a human maintainer unless that maintainer is
+actually the author of the commit.

--- a/docs/COMMIT_MESSAGE.md
+++ b/docs/COMMIT_MESSAGE.md
@@ -48,7 +48,7 @@ identity that names the model or tool and includes an email address. Keep
 the author string in this form:
 
 ```plain
-<model> <email>
+<model> <email@domain>
 ```
 
 Examples:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -118,7 +118,7 @@ Before opening a pull request, check that:
 Use Conventional Commits for commit messages.
 
 For commits created by an AI agent or AI-assisted tool, set the Git author
-to the model or tool identity in the form `<model> <email>`, such as
+to the model or tool identity in the form `<model> <email@domain>`, such as
 `GPT-5.5 <noreply@openai.com>` or
 `Copilot {model} <noreply@github.com>`.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -117,6 +117,11 @@ Before opening a pull request, check that:
 
 Use Conventional Commits for commit messages.
 
+For commits created by an AI agent or AI-assisted tool, set the Git author
+to the model or tool identity in the form `<model> <email>`, such as
+`GPT-5.5 <noreply@openai.com>` or
+`Copilot {model} <noreply@github.com>`.
+
 The repository includes a separate commit-message guide in
 `COMMIT_MESSAGE.md`. Follow that guide when preparing commits.
 


### PR DESCRIPTION
### Motivation

- Clarify repository guidance for commits produced or assisted by AI tools to ensure transparent authorship and provenance. 
- Prevent accidental attribution changes by instructing contributors to record the model/tool identity when an AI agent creates a commit.

### Description

- Add a bullet to the `AI Editing Rules` in `AGENTS.md` requiring AI-created commits to use a Git author identity in the form `<model> <email>` with examples. 
- Add a new section `## Commit author for AI-assisted commits` to `docs/COMMIT_MESSAGE.md` documenting the required author string format and examples such as `GPT-5.5 <noreply@openai.com>` and `Copilot {model} <noreply@github.com>`. 
- Update `docs/CONTRIBUTING.md` to reference the AI commit author rule alongside the existing guidance to use Conventional Commits.

### Testing

- Ran `git diff --check` to validate diffs and whitespace issues, which completed successfully. 
- Ran `git status --short --branch` to confirm working-tree and branch state, which reported the expected changes on `docs/ai-author`. 
- Inspected the latest commit with `git log -1 --pretty=fuller` to verify the authored commit metadata, which shows the AI-style author string as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e1e5f0320832a95ee005e8ef5203e)