### PR TITLE
docs: address build system review feedback

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -112,8 +112,8 @@ The expected repository layout is:
 treeView-beta
     "Taskfile.yml"
     "docs/"
-    "metadata.schema.json"
     "src/"
+        "metadata.schema.json"
         "<standard-publication>/"
             "metadata.yaml"
             "index.md"
@@ -191,6 +191,8 @@ When run from inside a custom publication directory, the publication Taskfile ha
 Always builds all publications from the repository root context.
 
 This task must not depend on the user's current working directory.
+
+Because Task uses a publication-local Taskfile before walking up to the repository root, repository-wide tasks must be invoked from the root Taskfile explicitly when the current directory might contain a publication Taskfile. Use the repository root as the working directory, or select the root Taskfile with `task --dir <repo-root> build:all` or `task --taskfile <repo-root>/Taskfile.yml build:all`.
 
 ### `task build:pub PUB=<publication-id>`
 
@@ -276,8 +278,12 @@ builds all publications
 
 ### Build all publications explicitly
 
+Run repository-wide tasks from the repository root, or explicitly select the root Taskfile when invoking them from another directory.
+
 ```sh
 task build:all
+# or, from another directory:
+task --dir <repo-root> build:all
 ```
 
 Expected behavior:
@@ -358,7 +364,7 @@ vars:
   SRC_DIR: src
   BUILD_DIR: build
   DIST_DIR: dist
-  METADATA_SCHEMA: metadata.schema.json
+  METADATA_SCHEMA: src/metadata.schema.json
 
 tasks:
   default:


### PR DESCRIPTION
### Motivation

- Address reviewer comments pointing Task validation at the repository's actual metadata schema location and avoid ambiguous repository-wide task behavior when publication-local Taskfiles exist.
- Prevent accidental invocation of publication Taskfiles for repository-wide tasks by clarifying how to explicitly select the root Taskfile.

### Description

- Update `docs/build-system.md` to document `src/metadata.schema.json` in the repository layout and set `METADATA_SCHEMA: src/metadata.schema.json` in the root Taskfile sketch.
- Add a clarification that repository-wide tasks (for example `build:all`) must be run from the repository root or invoked by explicitly selecting the root Taskfile with `task --dir <repo-root>` or `task --taskfile <repo-root>/Taskfile.yml`.
- Add an explicit non-root invocation example: `task --dir <repo-root> build:all` and adjust surrounding explanatory text for clarity.
- Apply small editorial adjustments to the spec to reflect the above changes.

### Testing

- Ran `git diff --check` and it completed with no whitespace or formatting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e24ec9c0c832abc7eeb36ebe19b09)